### PR TITLE
Refactor instrumentation trait from static to instance-based implementation with support for standalone functions

### DIFF
--- a/src/InstrumentationTrait.php
+++ b/src/InstrumentationTrait.php
@@ -12,11 +12,15 @@ use OpenTelemetry\Context\ContextStorageInterface;
 use OpenTelemetry\SemConv\TraceAttributes;
 use function OpenTelemetry\Instrumentation\hook;
 
+/**
+ *
+ */
 trait InstrumentationTrait {
   /**
-   * @var object|null */
+   * @var object|null*/
   protected ?object $instrumentation = NULL;
   protected ?string $attributePrefix = NULL;
+
   /**
    * @var \OpenTelemetry\API\Trace\SpanKind::KIND_* */
   protected int $spanKind = SpanKind::KIND_INTERNAL;
@@ -25,14 +29,14 @@ trait InstrumentationTrait {
   /**
    * Create new instrumentation with configuration options.
    *
-   * @param object|null $instrumentation
-   *   Optional pre-configured instrumentation.
+   * @param string|null $name
+   *   Name of the instrumentation if no CachedInstrumentation provided.
    * @param string|null $prefix
    *   Prefix for all span attributes.
    * @param \OpenTelemetry\API\Trace\SpanKind::KIND_* $spanKind
    *   Kind of spans to create (default: INTERNAL).
-   * @param string|null $name
-   *   Name of the instrumentation if no CachedInstrumentation provided.
+   * @param object|null $instrumentation
+   *   Optional pre-configured instrumentation.
    *
    * @throws \RuntimeException
    *   When neither instrumentation nor name is provided.
@@ -50,8 +54,11 @@ trait InstrumentationTrait {
     return $instance;
   }
 
-  // Final constructor, so we can use a factory method above.
-  final public function __construct() {}
+  /**
+ * Final constructor, so we can use a factory method above.
+ */
+  final public function __construct() {
+  }
 
   /**
    * Initialize the instrumentation with configuration options.
@@ -122,6 +129,9 @@ trait InstrumentationTrait {
     return $this->instrumentation;
   }
 
+  /**
+   *
+   */
   public function helperHook(
     string $methodName,
     array $paramMap = [],
@@ -144,6 +154,9 @@ trait InstrumentationTrait {
     return $this;
   }
 
+  /**
+   *
+   */
   protected function preHook(
     string $operation,
     array $resolvedParamMap = [],
@@ -156,7 +169,11 @@ trait InstrumentationTrait {
       string $function,
       ?string $filename,
       ?int $lineno,
-    ) use ($operation, $resolvedParamMap, $customHandler): void {
+    ) use (
+$operation,
+ $resolvedParamMap,
+ $customHandler
+): void {
       $parent = static::getCurrentContext();
 
       /** @var \OpenTelemetry\API\Instrumentation\CachedInstrumentation $instrumentation */
@@ -191,6 +208,9 @@ trait InstrumentationTrait {
     };
   }
 
+  /**
+   *
+   */
   protected function postHook(
     string $operation,
     ?string $resultAttribute = NULL,
@@ -201,7 +221,10 @@ trait InstrumentationTrait {
       array $params,
       $returnValue,
       ?\Throwable $exception,
-    ) use ($resultAttribute, $customHandler): void {
+    ) use (
+$resultAttribute,
+ $customHandler
+): void {
       $scope = static::getContextStorage()->scope();
       if (!$scope) {
         return;
@@ -230,6 +253,9 @@ trait InstrumentationTrait {
     };
   }
 
+  /**
+   *
+   */
   protected static function resolveParamPositions(
     ?string $className,
     string $methodName,
@@ -239,12 +265,13 @@ trait InstrumentationTrait {
       return [];
     }
 
-    if ($className === null) {
-        // Handle standalone functions
-        $reflection = new \ReflectionFunction($methodName);
-    } else {
-        // Handle class methods
-        $reflection = new \ReflectionMethod($className, $methodName);
+    if ($className === NULL) {
+      // Handle standalone functions.
+      $reflection = new \ReflectionFunction($methodName);
+    }
+    else {
+      // Handle class methods.
+      $reflection = new \ReflectionMethod($className, $methodName);
     }
 
     $parameters = $reflection->getParameters();
@@ -297,4 +324,5 @@ trait InstrumentationTrait {
   protected static function getSpanFromContext(ContextInterface $context): object {
     return Span::fromContext($context);
   }
+
 }

--- a/src/InstrumentationTrait.php
+++ b/src/InstrumentationTrait.php
@@ -12,9 +12,6 @@ use OpenTelemetry\Context\ContextStorageInterface;
 use OpenTelemetry\SemConv\TraceAttributes;
 use function OpenTelemetry\Instrumentation\hook;
 
-/**
- *
- */
 trait InstrumentationTrait {
   /**
    * @var object|null */
@@ -25,6 +22,21 @@ trait InstrumentationTrait {
   protected int $spanKind = SpanKind::KIND_INTERNAL;
   protected ?string $className = NULL;
 
+  /**
+   * Create new instrumentation with configuration options.
+   *
+   * @param object|null $instrumentation
+   *   Optional pre-configured instrumentation.
+   * @param string|null $prefix
+   *   Prefix for all span attributes.
+   * @param \OpenTelemetry\API\Trace\SpanKind::KIND_* $spanKind
+   *   Kind of spans to create (default: INTERNAL).
+   * @param string|null $name
+   *   Name of the instrumentation if no CachedInstrumentation provided.
+   *
+   * @throws \RuntimeException
+   *   When neither instrumentation nor name is provided.
+   */
   public static function create(
     string $name = NULL,
     ?string $prefix = NULL,
@@ -34,9 +46,12 @@ trait InstrumentationTrait {
   ): static {
     $instance = new static();
     $instance->className = $className;
-    $instance->initialize($instrumentation, $prefix, $spanKind, $name);
+    $instance->initialize(instrumentation: $instrumentation, prefix: $prefix, spanKind: $spanKind, name: $name);
     return $instance;
   }
+
+  // Final constructor, so we can use a factory method above.
+  final public function __construct() {}
 
   /**
    * Initialize the instrumentation with configuration options.

--- a/src/InstrumentationTrait.php
+++ b/src/InstrumentationTrait.php
@@ -42,11 +42,11 @@ trait InstrumentationTrait {
    *   When neither instrumentation nor name is provided.
    */
   public static function create(
-    string $name = NULL,
+    ?string $name = NULL,
     ?string $prefix = NULL,
     ?int $spanKind = SpanKind::KIND_INTERNAL,
     ?object $instrumentation = NULL,
-    ?string $className = NULL
+    ?string $className = NULL,
   ): static {
     $instance = new static();
     $instance->className = $className;
@@ -170,9 +170,9 @@ trait InstrumentationTrait {
       ?string $filename,
       ?int $lineno,
     ) use (
-$operation,
- $resolvedParamMap,
- $customHandler
+      $operation,
+      $resolvedParamMap,
+      $customHandler
 ): void {
       $parent = static::getCurrentContext();
 
@@ -222,8 +222,8 @@ $operation,
       $returnValue,
       ?\Throwable $exception,
     ) use (
-$resultAttribute,
- $customHandler
+      $resultAttribute,
+      $customHandler
 ): void {
       $scope = static::getContextStorage()->scope();
       if (!$scope) {

--- a/tests/InstrumentationTraitTest.php
+++ b/tests/InstrumentationTraitTest.php
@@ -69,6 +69,18 @@ class TestInstrumentation {
 
   /**
    * Creates and initializes the instrumentation.
+   *
+   * @param object|null $instrumentation
+   *   Optional pre-configured instrumentation.
+   * @param string|null $prefix
+   *   Prefix for all span attributes.
+   * @param \OpenTelemetry\API\Trace\SpanKind::KIND_* $spanKind
+   *   Kind of spans to create (default: INTERNAL).
+   * @param string|null $name
+   *   Name of the instrumentation if no CachedInstrumentation provided.
+   *
+   * @throws \RuntimeException
+   *   When neither instrumentation nor name is provided.
    */
   public static function create(
     object $instrumentation = NULL,
@@ -79,7 +91,11 @@ class TestInstrumentation {
   ): static {
     $targetClass = $className ?? static::CLASSNAME;
     $instance = static::createClass(instrumentation: $instrumentation, prefix: $prefix, spanKind: $spanKind, className: $targetClass, name: $name);
-    $instance->setTestSpan(static::$initialTestSpan);
+
+    if (static::$initialTestSpan) {
+      $instance->setTestSpan(static::$initialTestSpan);
+    }
+
     return $instance;
   }
 
@@ -208,8 +224,6 @@ class InstrumentationTraitTest extends TestCase {
   private TracerInterface $mockTracer;
 
   private TestCachedInstrumentation $testInstrumentation;
-
-  public static $staticMockSpan = NULL;
 
   /**
    *

--- a/tests/InstrumentationTraitTest.php
+++ b/tests/InstrumentationTraitTest.php
@@ -87,11 +87,11 @@ class TestInstrumentation {
    *   When neither instrumentation nor name is provided.
    */
   public static function create(
-    object $instrumentation = NULL,
+    ?object $instrumentation = NULL,
     ?string $prefix = NULL,
     ?int $spanKind = SpanKind::KIND_INTERNAL,
     ?string $className = NULL,
-    ?string $name = NULL
+    ?string $name = NULL,
   ): static {
     $targetClass = $className ?? static::CLASSNAME;
     $instance = static::createClass(instrumentation: $instrumentation, prefix: $prefix, spanKind: $spanKind, className: $targetClass, name: $name);

--- a/tests/InstrumentationTraitTest.php
+++ b/tests/InstrumentationTraitTest.php
@@ -258,6 +258,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::getInstrumentation
@@ -268,6 +269,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -307,6 +309,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -347,6 +350,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -384,6 +388,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -418,6 +423,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -443,6 +449,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -476,6 +483,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    */
@@ -487,6 +495,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -525,6 +534,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -556,6 +566,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -596,6 +607,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -627,6 +639,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -660,6 +673,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook
@@ -692,6 +706,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::getInstrumentation
@@ -706,6 +721,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::getSpanFromContext
@@ -723,6 +739,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::getContextStorage
@@ -748,6 +765,7 @@ class InstrumentationTraitTest extends TestCase {
   }
 
   /**
+   * @covers ::__construct
    * @covers ::create
    * @covers ::initialize
    * @covers ::helperHook


### PR DESCRIPTION
```markdown
# Changelog

## [1.1.0] - 2024-01-28

### Breaking Changes
- Changed from static to instance-based implementation
- Removed `initialize()` static method in favor of `create()`
- Changed how instrumentations are configured and hooks are registered
- Changed scope of `getAttributeName()` from static to instance method

### Added
- Support for standalone PHP functions (not just class methods)
- Fluent interface for registering multiple hooks
- Better type safety and null handling
- More flexible class name handling

### Migration Guide

#### Before (1.0.0)
```php
class MyInstrumentation {
    use InstrumentationTrait;
    
    protected const CLASSNAME = MyClass::class;
    
    public static function register(): void {
        // Static initialization
        static::initialize(
            name: 'my.instrumentation',
            prefix: 'my.prefix'
        );
        
        // Static hook registration
        static::helperHook(
            self::CLASSNAME,
            'myMethod',
            ['param1', 'param2'],
            'returnValue'
        );
        
        static::helperHook(
            self::CLASSNAME,
            'otherMethod',
            ['param3']
        );
    }
}
```

#### After (1.1.0)
```php
class MyInstrumentation {
    use InstrumentationTrait;
    
    public static function register(): void {
        // Create instance with configuration
        $instrumentation = self::create(
            name: 'my.instrumentation',
            prefix: 'my.prefix',
            className: MyClass::class  // Optional, can be set per hook
        );
        
        // Fluent hook registration
        $instrumentation
            ->helperHook(
                'myMethod',
                ['param1', 'param2'],
                'returnValue'
            )
            ->helperHook(
                'otherMethod',
                ['param3']
            );
    }
}
```

#### Key Changes to Update

1. Replace `initialize()` with `create()`
   - Move from static initialization to creating an instance
   - Configuration options are similar but passed to `create()`

2. Update Handler Functions
   - Change `static::getAttributeName()` to `$this->getAttributeName()`
   ```php
   // Before
   preHandler: function($spanBuilder) {
       $spanBuilder->setAttribute(static::getAttributeName('key'), 'value');
   }
   
   // After
   preHandler: function($spanBuilder) {
       $spanBuilder->setAttribute($this->getAttributeName('key'), 'value');
   }
   ```

3. Update Hook Registration
   - Remove class name constant if used only for hooks
   - Class name can be set globally in `create()` or per hook
   - Use fluent interface for multiple hooks
   ```php
   // Before
   static::helperHook(self::CLASSNAME, 'method', ...);
   static::helperHook(self::CLASSNAME, 'other', ...);
   
   // After
   $instrumentation
       ->helperHook('method', ...)
       ->helperHook('other', ...);
   ```

4. Standalone Functions
   - Now supports instrumenting PHP functions
   ```php
   $instrumentation->helperHook(
       'apcu_fetch',
       ['key'],
       'returnValue'
   );
   ```

### Internal Changes
- Improved error handling and type safety
- Better separation of concerns
- More consistent attribute handling
- Enhanced support for testing and mocking
```